### PR TITLE
fix: publish permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  packages: write
+  pages: write
+
 jobs:
   dokka:
     uses: ./.github/workflows/dokka.yml


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to include additional permissions for the `publish.yml` workflow. These permissions are necessary for writing to contents, packages, and pages.

### Workflow configuration updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R9-R13): Added `permissions` block to grant `write` access to `contents`, `packages`, and `pages`, ensuring the workflow has the necessary permissions to perform publishing tasks.