### PR TITLE
develop

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,7 @@ publishing {
         // Publish to GitHub Packages
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/adjmunro/inline")
+            url = uri("https://maven.pkg.github.com/adjmunro/project-inline")
             credentials {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")

--- a/src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.kt
+++ b/src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.kt
@@ -68,9 +68,6 @@ class ReturnExtTest {
 
     @Test
     fun `nulls should always return null when ignore is default`(): TestResult = runTest {
-        // Given: any value
-        val value = "anything"
-
         // When: nulls is called with default ignore
         val result = nulls()
 
@@ -92,9 +89,6 @@ class ReturnExtTest {
 
     @Test
     fun `unit should always return Unit when ignore is default`(): TestResult = runTest {
-        // Given: any value
-        val value = "anything"
-
         // When: unit is called with default ignore
         val result = unit()
 
@@ -116,9 +110,6 @@ class ReturnExtTest {
 
     @Test
     fun `truth should always return true when ignore is default`(): TestResult = runTest {
-        // Given: any value
-        val value = "anything"
-
         // When: truth is called with default ignore
         val result = truth()
 
@@ -140,9 +131,6 @@ class ReturnExtTest {
 
     @Test
     fun `falsehood should always return false when ignore is default`(): TestResult = runTest {
-        // Given: any value
-        val value = "anything"
-
         // When: falsehood is called with default ignore
         val result = falsehood()
 


### PR DESCRIPTION
This pull request simplifies the test cases in the `ReturnExtTest` class by removing redundant "Given" sections that declared unused variables. These changes streamline the tests without altering their functionality.

Test case simplifications:

* Removed the "Given" section declaring an unused `value` variable in the `nulls` test. (`src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.kt`, [src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.ktL71-L73](diffhunk://#diff-e189ff098dd8efc76c37b0c995f3aeff65b225f3ccf970ce705430088d98449dL71-L73))
* Removed the "Given" section declaring an unused `value` variable in the `unit` test. (`src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.kt`, [src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.ktL95-L97](diffhunk://#diff-e189ff098dd8efc76c37b0c995f3aeff65b225f3ccf970ce705430088d98449dL95-L97))
* Removed the "Given" section declaring an unused `value` variable in the `truth` test. (`src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.kt`, [src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.ktL119-L121](diffhunk://#diff-e189ff098dd8efc76c37b0c995f3aeff65b225f3ccf970ce705430088d98449dL119-L121))
* Removed the "Given" section declaring an unused `value` variable in the `falsehood` test. (`src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.kt`, [src/test/kotlin/nz/adjmunro/inline/ReturnExtTest.ktL143-L145](diffhunk://#diff-e189ff098dd8efc76c37b0c995f3aeff65b225f3ccf970ce705430088d98449dL143-L145))